### PR TITLE
feat: make Scale and Resolution editable number inputs

### DIFF
--- a/src/steps/Render.module.scss
+++ b/src/steps/Render.module.scss
@@ -22,6 +22,33 @@
   }
 }
 
+.settings {
+  margin-bottom: 1rem;
+}
+
+.settings > div {
+  margin-bottom: 0.8rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.settings > div > span {
+  display: inline-block;
+  min-width: 5rem;
+}
+
+.settings input[type="number"],
+.settings input[type="range"] {
+  margin: 0 0.25rem;
+}
+
+.sliderContainer {
+  min-width: 120px;
+  flex: 1;
+}
+
 .info,
 .actions {
   margin-bottom: 0.25rem;

--- a/src/steps/Render.tsx
+++ b/src/steps/Render.tsx
@@ -119,20 +119,73 @@ export const Render: React.FC = observer(() => {
         <>
           <div className={styles.settings}>
             <div>
-              Resolution: {width}px x {height}px
+              <span>Resolution: </span>
+              <div>
+                <input
+                  type="number"
+                  value={width}
+                  min={2}
+                  step={2}
+                  onChange={e => {
+                    const newWidth = parseInt(e.target.value, 10);
+                    if (!isNaN(newWidth) && newWidth > 0) {
+                      const baseWidth = area ? area[2] : video.videoWidth;
+                      const newScale = Math.max(0.1, Math.min(1, newWidth / baseWidth));
+                      runInAction(() => {
+                        mainStore.transform.scale = newScale;
+                      });
+                    }
+                  }}
+                />
+                <span>x</span>
+                <input
+                  type="number"
+                  value={height}
+                  min={2}
+                  step={2}
+                  onChange={e => {
+                    const newHeight = parseInt(e.target.value, 10);
+                    if (!isNaN(newHeight) && newHeight > 0) {
+                      const baseHeight = area ? area[3] : video.videoHeight;
+                      const newScale = Math.max(0.1, Math.min(1, newHeight / baseHeight));
+                      runInAction(() => {
+                        mainStore.transform.scale = newScale;
+                      });
+                    }
+                  }}
+                />
+                <span>px</span>
+              </div>
             </div>
             <div>
-              Scale: {Math.round(scale * 100) / 100}
-              <Slider
+              <span>Scale: </span>
+              <input
+                type="number"
+                value={Math.round(scale * 100) / 100}
                 min={0.1}
                 max={1}
-                value={scale}
-                onChange={value => {
-                  runInAction(() => {
-                    mainStore.transform.scale = value;
-                  });
+                step={0.01}
+                onChange={e => {
+                  const newScale = parseFloat(e.target.value);
+                  if (!isNaN(newScale) && newScale >= 0.1 && newScale <= 1) {
+                    runInAction(() => {
+                      mainStore.transform.scale = newScale;
+                    });
+                  }
                 }}
               />
+              <div className={styles.sliderContainer}>
+                <Slider
+                  min={0.1}
+                  max={1}
+                  value={scale}
+                  onChange={value => {
+                    runInAction(() => {
+                      mainStore.transform.scale = value;
+                    });
+                  }}
+                />
+              </div>
             </div>
           </div>
           <div className={styles.actions}>


### PR DESCRIPTION
## Description
Fixes #1

This PR makes Scale and Resolution inputs editable number controls instead of just range sliders.

### Changes
- Added number input fields for Scale (0.1 - 1.0) allowing direct numeric entry
- Added number inputs for Resolution (width and height) that sync with the scale
- Kept the original Slider component alongside number input for Scale for better UX
- Maintained two-row layout for clarity: Resolution on first row, Scale on second row

### Testing
The changes allow users to:
1. Directly type a scale value (e.g., 0.5) instead of only using the slider
2. Set custom resolution dimensions and have them automatically adjust the scale
3. Use both number inputs and slider interchangeably - they stay in sync